### PR TITLE
test: add test macros and auxiliary functions

### DIFF
--- a/src/main/component.cljs
+++ b/src/main/component.cljs
@@ -3,6 +3,7 @@
             ["@mantine/hooks" :refer [useDisclosure]]
             [helix.core :refer [$ <>]]
             [helix.dom :as d]
+            [helix.hooks :as hooks]
             [main.lib :refer [defnc]]))
 
 (def theme
@@ -20,6 +21,12 @@
 
 (defnc button [{:keys [color on-click text]}]
   ($ Button {:color color :onClick on-click} text))
+
+(defnc counter []
+  (let [[count set-count] (hooks/use-state 0)]
+    (d/div
+     (d/p "Count: " count)
+     ($ button {:color "blue" :on-click #(set-count inc) :text "Increase"}))))
 
 (defnc app-shell []
   (let [[opened fns] (useDisclosure)

--- a/src/portfolio/scenes/component_scene.cljs
+++ b/src/portfolio/scenes/component_scene.cljs
@@ -7,15 +7,10 @@
             [main.lib :refer [defnc]]
             [portfolio.react-18 :refer-macros [defscene]]))
 
-(defnc counter []
-  (let [[count set-count] (hooks/use-state 0)]
-    (d/div
-     (d/p "Count: " count)
-     (d/button {:on-click #(set-count inc)} "Increase"))))
-
-(defscene helix-counter
-  :title "Counter with React Hooks"
-  ($ counter))
+(defscene mantine-helix-hooks-counter
+  :title "Counter with React Hooks and Mantine"
+  ($ MantineProvider {:theme c/theme}
+    ($ c/counter)))
 
 (defscene component-boolean-true
   (d/div (d/h1 "helix-jsdom")

--- a/tests/aux.cljs
+++ b/tests/aux.cljs
@@ -46,3 +46,20 @@
 (defn sync-setup [f]
   (f)
   (tlr/cleanup))
+
+(defn screen [] (tlr/within js/document))
+
+(defn get-by-text [text]
+  (.getByText (screen) text))
+
+(defn find-by-text [text]
+  (.findByText (screen) text))
+
+(defn get-all-by-role [role]
+  (.getAllByRole (screen) role))
+
+(defn click! [element]
+  (.click tlr/fireEvent element))
+
+(defn ->text [element]
+  (.-text element))

--- a/tests/aux.cljs
+++ b/tests/aux.cljs
@@ -47,19 +47,23 @@
   (f)
   (tlr/cleanup))
 
-(defn screen [] (tlr/within js/document))
+(defn render [component] 
+  (tlr/render component))
+
+(defn screen [] 
+  (tlr/within js/document))
 
 (defn get-by-text [text]
   (.getByText (screen) text))
-
-(defn find-by-text [text]
-  (.findByText (screen) text))
 
 (defn get-all-by-role [role]
   (.getAllByRole (screen) role))
 
 (defn click! [element]
   (.click tlr/fireEvent element))
+
+(defn wait [f]
+  (tlr/waitFor f))
 
 (defn ->text [element]
   (.-text element))

--- a/tests/main/mantine_test.cljs
+++ b/tests/main/mantine_test.cljs
@@ -1,18 +1,17 @@
 (ns main.mantine-test
   (:require ["@mantine/core" :refer [Group MantineProvider NavLink Button]]
-            ["@testing-library/react" :as tlr]
-            [aux :refer [->text get-by-text get-all-by-role get-by-text click!] :as aux]
-            [test-lib :refer [async wait]]
+            [aux :as aux :refer [get-all-by-role get-by-text click! wait ->text]]
+            [test-lib :refer [async]]
             [cljs.test :refer [deftest is testing use-fixtures]]
             [clojure.string :as str]
             [helix.core :refer [$]]
             [helix.dom :as d]
-            [helix.hooks :as hooks]
+            [main.component :as c]
             [main.lib :refer [defnc]]
             [promesa.core :as p]))
 
 (defn render [component]
-  (tlr/render ($ MantineProvider component)))
+  (aux/render ($ MantineProvider component)))
 
 (use-fixtures :each
   {:before aux/async-setup
@@ -25,12 +24,6 @@
      ($ NavLink {:label "b"
                  :href "www.example.com/b"})))
 
-(defnc MyCounter []
-  (let [[count set-count] (hooks/use-state 0)]
-    (d/div
-     (d/p "Count: " count)
-     ($ Button {:onClick #(set-count inc)} "Increase"))))
-
 (deftest mantine-test-sync
   (testing "should render mantine component links"
      (render ($ MyNavLinks))
@@ -40,7 +33,7 @@
 (deftest mantine-test-async
   (testing "should render counter, after click, should change state to 1"
     (async
-      (render ($ MyCounter))
+      (render ($ c/counter))
       (is (some? (get-by-text "Count: 0")))
       (click! (get-by-text "Increase"))
-      (wait (is (some? (get-by-text "Count: 1")))))))
+      (wait #(is (some? (get-by-text "Count: 1")))))))

--- a/tests/main/mantine_test.cljs
+++ b/tests/main/mantine_test.cljs
@@ -1,12 +1,18 @@
 (ns main.mantine-test
-  (:require ["@mantine/core" :refer [Group MantineProvider NavLink]]
+  (:require ["@mantine/core" :refer [Group MantineProvider NavLink Button]]
             ["@testing-library/react" :as tlr]
-            [aux :as aux]
-            [cljs.test :refer [async deftest is testing use-fixtures]]
+            [aux :refer [->text get-by-text get-all-by-role get-by-text click!] :as aux]
+            [test-lib :refer [async wait]]
+            [cljs.test :refer [deftest is testing use-fixtures]]
             [clojure.string :as str]
             [helix.core :refer [$]]
+            [helix.dom :as d]
+            [helix.hooks :as hooks]
             [main.lib :refer [defnc]]
             [promesa.core :as p]))
+
+(defn render [component]
+  (tlr/render ($ MantineProvider component)))
 
 (use-fixtures :each
   {:before aux/async-setup
@@ -19,20 +25,22 @@
      ($ NavLink {:label "b"
                  :href "www.example.com/b"})))
 
-(deftest mantine-test
+(defnc MyCounter []
+  (let [[count set-count] (hooks/use-state 0)]
+    (d/div
+     (d/p "Count: " count)
+     ($ Button {:onClick #(set-count inc)} "Increase"))))
+
+(deftest mantine-test-sync
   (testing "should render mantine component links"
-    (async done
-      (p/catch
-        (p/let [groups (tlr/waitFor #(-> (tlr/render
-                                          ($ MantineProvider ($ MyNavLinks)))
-                                         (.findByTestId "link-groups")))
-                links (->> (.querySelectorAll groups ".mantine-NavLink-root")
-                           (mapv #(-> % .-href (str/split "/") last)))]
+     (render ($ MyNavLinks))
+     (is (= ["a" "b"]
+            (map ->text (get-all-by-role "link"))))))
 
-          (is (= ["a" "b"]
-                 links))
-
-          (done))
-        (fn [err]
-          (is (= nil err))
-          (done))))))
+(deftest mantine-test-async
+  (testing "should render counter, after click, should change state to 1"
+    (async
+      (render ($ MyCounter))
+      (is (some? (get-by-text "Count: 0")))
+      (click! (get-by-text "Increase"))
+      (wait (is (some? (get-by-text "Count: 1")))))))

--- a/tests/test_lib.cljc
+++ b/tests/test_lib.cljc
@@ -1,0 +1,19 @@
+(ns test-lib
+  #?(:clj (:require [promesa.core :as p]
+                    [cljs.test :as t]))
+  #?(:cljs (:require-macros [test-lib])))
+
+#?(:clj
+    (defmacro async
+      [& body]
+      `(t/async done#
+         (p/catch
+           (p/do ~@body (done#))
+           (fn [err#]
+             (is (= nil err#))
+             (done#))))))
+
+#?(:clj
+    (defmacro wait
+      [& body]
+      `(tlr/waitFor (fn [] ~@body))))

--- a/tests/test_lib.cljc
+++ b/tests/test_lib.cljc
@@ -1,19 +1,14 @@
 (ns test-lib
-  #?(:clj (:require [promesa.core :as p]
-                    [cljs.test :as t]))
+  #?(:clj (:require [cljs.test :as t]
+                    [promesa.core :as p]))
   #?(:cljs (:require-macros [test-lib])))
 
 #?(:clj
     (defmacro async
       [& body]
-      `(t/async done#
-         (p/catch
-           (p/do ~@body (done#))
+      `(cljs.test/async done#
+         (promesa.core/catch
+           (promesa.core/do ~@body (done#))
            (fn [err#]
              (is (= nil err#))
              (done#))))))
-
-#?(:clj
-    (defmacro wait
-      [& body]
-      `(tlr/waitFor (fn [] ~@body))))


### PR DESCRIPTION
This commit adds some test macros to help dealing with some of the async flows from Javascript.
Furthermore it adds a new example to the mantine-test testing suite to show an instance of a synchronous test.
Tests that "just render components" and verifies the rendered screen can be done synchronously.
Components that have side effect, states and user interactions, on the other hand have to be tested asynchronously.
Please, note the `screen` function instead of the screen variable from react testing library. Although it has the exact same effect, that's been done to work around the js/document only being hooked up after the testing library is loaded.