### PR TITLE
feat: Add custom portfolio canvas with forced light mantine theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ public/app
 public/portfolio
 !public/app/index.html
 !public/portfolio/index.html
+!public/portfolio/custom-canvas.html
 
 /out
 /checkouts

--- a/public/portfolio/custom-canvas.html
+++ b/public/portfolio/custom-canvas.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en" data-mantine-color-scheme="light">
+  <head>
+    <title>Portfolio Canvas</title>
+  </head>
+  <body>
+    <main id="canvas" role="main"></main>
+  </body>
+</html>
+

--- a/src/portfolio/core.cljs
+++ b/src/portfolio/core.cljs
@@ -5,4 +5,5 @@
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn init
   []
-  (ui/start! {:config {:css-paths ["/app/app.css"]}}))
+  (ui/start! {:config {:css-paths ["/app/app.css"]
+                       :canvas-path "/portfolio/custom-canvas.html"}}))


### PR DESCRIPTION
See https://github.com/cjohansen/portfolio/issues/21#issuecomment-1927636020 for more context. This is a workaround to force set the theme in the porfolio canvas.
Not ideal as the theme between the application and the canvas could get out of sync, but it helps visualizing and interacting with the component nonetheless.