### PR TITLE
fix: fail test command if any test fails

### DIFF
--- a/tests/node.cljs
+++ b/tests/node.cljs
@@ -2,6 +2,11 @@
   (:require ["global-jsdom" :as global-jsdom]
             [cljs.test :as test]))
 
+(defmethod test/report [::test/default :end-run-tests] [m]
+  (if (test/successful? m)
+    (js/process.exit 0)
+    (js/process.exit 1)))
+
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn main []
   (global-jsdom)


### PR DESCRIPTION
Adds a custom report to exit the process with `0` when tests are successful, or `1` otherwise.
<img width="504" alt="image" src="https://github.com/rafaeldelboni/helix-jsdom-portfolio-mantine/assets/49727703/a38f2756-accf-47e4-98ff-fd43c5679da9">