### PR TITLE
Add bundle support with esbuild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ pom.xml.asc
 
 .hgignore
 .hg/
+
+.bundle.meta.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@mantine/core": "^7.4.2",
         "@mantine/hooks": "^7.4.2",
+        "esbuild": "^0.20.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-refresh": "^0.13.0"
@@ -198,6 +199,351 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.1.tgz",
+      "integrity": "sha512-m55cpeupQ2DbuRGQMMZDzbv9J9PgVelPjlcmM5kxHnrBdBx6REaEd7LamYV7Dm8N7rCyR/XwU6rVP8ploKtIkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.20.1.tgz",
+      "integrity": "sha512-4j0+G27/2ZXGWR5okcJi7pQYhmkVgb4D7UKwxcqrjhvp5TKWx3cUjgB1CGj1mfdmJBQ9VnUGgUhign+FPF2Zgw==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.20.1.tgz",
+      "integrity": "sha512-hCnXNF0HM6AjowP+Zou0ZJMWWa1VkD77BXe959zERgGJBBxB+sV+J9f/rcjeg2c5bsukD/n17RKWXGFCO5dD5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.1.tgz",
+      "integrity": "sha512-MSfZMBoAsnhpS+2yMFYIQUPs8Z19ajwfuaSZx+tSl09xrHZCjbeXXMsUF/0oq7ojxYEpsSo4c0SfjxOYXRbpaA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.1.tgz",
+      "integrity": "sha512-Ylk6rzgMD8klUklGPzS414UQLa5NPXZD5tf8JmQU8GQrj6BrFA/Ic9tb2zRe1kOZyCbGl+e8VMbDRazCEBqPvA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.20.1.tgz",
+      "integrity": "sha512-pFIfj7U2w5sMp52wTY1XVOdoxw+GDwy9FsK3OFz4BpMAjvZVs0dT1VXs8aQm22nhwoIWUmIRaE+4xow8xfIDZA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.1.tgz",
+      "integrity": "sha512-UyW1WZvHDuM4xDz0jWun4qtQFauNdXjXOtIy7SYdf7pbxSWWVlqhnR/T2TpX6LX5NI62spt0a3ldIIEkPM6RHw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.20.1.tgz",
+      "integrity": "sha512-itPwCw5C+Jh/c624vcDd9kRCCZVpzpQn8dtwoYIt2TJF3S9xJLiRohnnNrKwREvcZYx0n8sCSbvGH349XkcQeg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.20.1.tgz",
+      "integrity": "sha512-LojC28v3+IhIbfQ+Vu4Ut5n3wKcgTu6POKIHN9Wpt0HnfgUGlBuyDDQR4jWZUZFyYLiz4RBBBmfU6sNfn6RhLw==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.20.1.tgz",
+      "integrity": "sha512-cX8WdlF6Cnvw/DO9/X7XLH2J6CkBnz7Twjpk56cshk9sjYVcuh4sXQBy5bmTwzBjNVZze2yaV1vtcJS04LbN8w==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.20.1.tgz",
+      "integrity": "sha512-4H/sQCy1mnnGkUt/xszaLlYJVTz3W9ep52xEefGtd6yXDQbz/5fZE5dFLUgsPdbUOQANcVUa5iO6g3nyy5BJiw==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.20.1.tgz",
+      "integrity": "sha512-c0jgtB+sRHCciVXlyjDcWb2FUuzlGVRwGXgI+3WqKOIuoo8AmZAddzeOHeYLtD+dmtHw3B4Xo9wAUdjlfW5yYA==",
+      "cpu": [
+        "loong64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.20.1.tgz",
+      "integrity": "sha512-TgFyCfIxSujyuqdZKDZ3yTwWiGv+KnlOeXXitCQ+trDODJ+ZtGOzLkSWngynP0HZnTsDyBbPy7GWVXWaEl6lhA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.20.1.tgz",
+      "integrity": "sha512-b+yuD1IUeL+Y93PmFZDZFIElwbmFfIKLKlYI8M6tRyzE6u7oEP7onGk0vZRh8wfVGC2dZoy0EqX1V8qok4qHaw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.20.1.tgz",
+      "integrity": "sha512-wpDlpE0oRKZwX+GfomcALcouqjjV8MIX8DyTrxfyCfXxoKQSDm45CZr9fanJ4F6ckD4yDEPT98SrjvLwIqUCgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.20.1.tgz",
+      "integrity": "sha512-5BepC2Au80EohQ2dBpyTquqGCES7++p7G+7lXe1bAIvMdXm4YYcEfZtQrP4gaoZ96Wv1Ute61CEHFU7h4FMueQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.1.tgz",
+      "integrity": "sha512-5gRPk7pKuaIB+tmH+yKd2aQTRpqlf1E4f/mC+tawIm/CGJemZcHZpp2ic8oD83nKgUPMEd0fNanrnFljiruuyA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.1.tgz",
+      "integrity": "sha512-4fL68JdrLV2nVW2AaWZBv3XEm3Ae3NZn/7qy2KGAt3dexAgSVT+Hc97JKSZnqezgMlv9x6KV0ZkZY7UO5cNLCg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.1.tgz",
+      "integrity": "sha512-GhRuXlvRE+twf2ES+8REbeCb/zeikNqwD3+6S5y5/x+DYbAQUNl0HNBs4RQJqrechS4v4MruEr8ZtAin/hK5iw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.20.1.tgz",
+      "integrity": "sha512-ZnWEyCM0G1Ex6JtsygvC3KUUrlDXqOihw8RicRuQAzw+c4f1D66YlPNNV3rkjVW90zXVsHwZYWbJh3v+oQFM9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.20.1.tgz",
+      "integrity": "sha512-QZ6gXue0vVQY2Oon9WyLFCdSuYbXSoxaZrPuJ4c20j6ICedfsDilNPYfHLlMH7vGfU5DQR0czHLmJvH4Nzis/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.20.1.tgz",
+      "integrity": "sha512-HzcJa1NcSWTAU0MJIxOho8JftNp9YALui3o+Ny7hCh0v5f90nprly1U3Sj1Ldj/CvKKdvvFsCRvDkpsEMp4DNw==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.1.tgz",
+      "integrity": "sha512-0MBh53o6XtI6ctDnRMeQ+xoCN8kD2qI1rY1KgF/xdWQwoFeKou7puvDfV8/Wv4Ctx2rRpET/gGdz3YlNtNACSA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@floating-ui/core": {
@@ -1578,6 +1924,43 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.1.tgz",
+      "integrity": "sha512-OJwEgrpWm/PCMsLVWXKqvcjme3bHNpOgN7Tb6cQnR5n0TPbQx1/Xrn7rqM+wn17bYeT6MGB5sn1Bh5YiGi70nA==",
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.20.1",
+        "@esbuild/android-arm": "0.20.1",
+        "@esbuild/android-arm64": "0.20.1",
+        "@esbuild/android-x64": "0.20.1",
+        "@esbuild/darwin-arm64": "0.20.1",
+        "@esbuild/darwin-x64": "0.20.1",
+        "@esbuild/freebsd-arm64": "0.20.1",
+        "@esbuild/freebsd-x64": "0.20.1",
+        "@esbuild/linux-arm": "0.20.1",
+        "@esbuild/linux-arm64": "0.20.1",
+        "@esbuild/linux-ia32": "0.20.1",
+        "@esbuild/linux-loong64": "0.20.1",
+        "@esbuild/linux-mips64el": "0.20.1",
+        "@esbuild/linux-ppc64": "0.20.1",
+        "@esbuild/linux-riscv64": "0.20.1",
+        "@esbuild/linux-s390x": "0.20.1",
+        "@esbuild/linux-x64": "0.20.1",
+        "@esbuild/netbsd-x64": "0.20.1",
+        "@esbuild/openbsd-x64": "0.20.1",
+        "@esbuild/sunos-x64": "0.20.1",
+        "@esbuild/win32-arm64": "0.20.1",
+        "@esbuild/win32-ia32": "0.20.1",
+        "@esbuild/win32-x64": "0.20.1"
       }
     },
     "node_modules/escalade": {

--- a/package.json
+++ b/package.json
@@ -9,12 +9,16 @@
     "release:clj": "shadow-cljs release app",
     "test:watch": "shadow-cljs watch node-tests --config-merge \"{:autorun true}\"",
     "test": "shadow-cljs compile node-tests && node out/node-tests.js",
-    "start": "conc npm:watch:*",
-    "release": "conc npm:release:*"
+    "start": "conc -c auto npm:watch:*",
+    "release": "conc -c auto npm:release:* && npm run bundle:optimize",
+    "bundle": "esbuild --bundle public/app/lib.js --outfile=public/app/lib.bundle.js",
+    "watch:bundle": "npm run bundle -- --watch",
+    "bundle:optimize": "npm run bundle --  --analyze --metafile=.bundle.meta.json --define:NODE_ENV=production --minify"
   },
   "dependencies": {
     "@mantine/core": "^7.4.2",
     "@mantine/hooks": "^7.4.2",
+    "esbuild": "^0.20.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-refresh": "^0.13.0"

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -11,6 +11,7 @@
 
 <body>
   <main id="app"></main>
+  <script src="./lib.bundle.js"></script>
   <script src="./main.js"></script>
 </body>
 

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -10,7 +10,11 @@
                 :output-dir "public/app"
                 :asset-path "/app"
                 :modules          {:main {:init-fn main.app/init}}
-                :compiler-options {:install-deps true}}
+                :compiler-options {:install-deps true}
+                :js-options 
+                {:js-provider :external
+                    :external-index "public/app/lib.js"
+                    :external-index-format :esm}}
 
           :portfolio {:target :browser
                       :output-dir "public/portfolio"

--- a/src/main/component.cljs
+++ b/src/main/component.cljs
@@ -1,14 +1,13 @@
 (ns main.component
-  (:require ["@mantine/core" :refer [AppShell Burger Button createTheme Group
-                                     Skeleton]]
-            ["@mantine/hooks" :refer [useDisclosure]]
+  (:require ["@mantine/core" :as mc]
+            ["@mantine/hooks" :as mh]
             [helix.core :refer [$ <>]]
             [helix.dom :as d]
             [helix.hooks :as hooks]
             [main.lib :refer [defnc]]))
 
 (def theme
-  (createTheme
+  (mc/createTheme
    (clj->js
     {:colors {:deep-blue ["#eef3ff" "#dce4f5" "#b9c7e2" "#94a8d0" "#748dc1" "#5f7cb8" "#5474b4" "#44639f" "#39588f" "#2d4b81"]
               :yellow-king ["#fafae8" "#f0f1da" "#e0e1b9" "#cfd094" "#c0c274" "#b7b95f" "#b2b454" "#9c9e44" "#8a8c39" "#767a2b"]}
@@ -21,7 +20,7 @@
   (<> (if value "yes" "no")))
 
 (defnc button [{:keys [color on-click text]}]
-  ($ Button {:color color :onClick on-click} text))
+  ($ mc/Button {:color color :onClick on-click} text))
 
 (defnc counter []
   (let [[count set-count] (hooks/use-state 0)]
@@ -30,27 +29,27 @@
       ($ button {:color "blue" :on-click #(set-count inc) :text "Increase"}))))
 
 (defnc app-shell []
-  (let [[opened fns] (useDisclosure)
+  (let [[opened fns] (mh/useDisclosure)
         {:keys [toggle]} (js->clj fns :keywordize-keys true)]
-    ($ AppShell {:padding "md"
-                 :header #js {:height 60}
-                 :navbar #js {:width 300
-                              :breakpoint "md"
-                              :collapsed #js {:mobile (not opened)}}}
+    ($ mc/AppShell {:padding "md"
+                    :header #js {:height 60}
+                    :navbar #js {:width 300
+                                 :breakpoint "md"
+                                 :collapsed #js {:mobile (not opened)}}}
 
-       ($ AppShell.Header
-          ($ Group {:h "100%" :px "md"}
-             ($ Burger {:opened opened
-                        :onClick toggle
-                        :hiddenFrom "sm"
-                        :size "sm"})
+       ($ mc/AppShell.Header
+          ($ mc/Group {:h "100%" :px "md"}
+             ($ mc/Burger {:opened opened
+                           :onClick toggle
+                           :hiddenFrom "sm"
+                           :size "sm"})
              (d/div "Helix + Mantine")))
 
-       ($ AppShell.Navbar {:p "md"}
+       ($ mc/AppShell.Navbar {:p "md"}
           (for [index (range 10)]
-            ($ Skeleton {:key index :h 28 :mt "sm" :animate false})))
+            ($ mc/Skeleton {:key index :h 28 :mt "sm" :animate false})))
 
-       ($ AppShell.Main
+       ($ mc/AppShell.Main
           (d/h1 "helix-jsdom-portfolio-mantine")
           ($ button {:text "My Button"
                      :on-click #(js/console.log "clicked!")


### PR DESCRIPTION
* Added bundle support using esbuild, which means
  * Split cljs output into lib and main. main contains our code, while lib contains vendor code. lib is generated using esm module syntax, which allows for external tools to tree shake it.
  * tree shaking is done using esbuild.
  * The code generated by shadow-clj will descontruct the imports when we use the :refer syntax and that does not play well with the vendors being in another script (shadow bridge),thus we have to update the requires from cljs to use the :as syntax
  
---

This reduces the bundle from `1.4 mb` to `201.5kb`. (gzipped would be around 65kb)
(Using the analyzer from [esbuild](https://esbuild.github.io/analyze/) and the generated metadata file at `.bundle.meta.json`
<img width="1107" alt="image" src="https://github.com/rafaeldelboni/helix-jsdom-portfolio-mantine/assets/49727703/8328aba0-bb33-4acd-b9b2-1f94966b2e95">