### PR TITLE
fix: Return refer syntax

### DIFF
--- a/src/main/app.cljs
+++ b/src/main/app.cljs
@@ -1,6 +1,6 @@
 (ns main.app
   (:require ["@mantine/core" :refer [MantineProvider]]
-            ["react-dom/client" :as rdom]
+            ["react-dom/client" :refer [createRoot]]
             [helix.core :refer [$]]
             [main.component :refer [app-shell theme]]
             [main.lib :refer [defnc]]))
@@ -10,7 +10,7 @@
      ($ app-shell)))
 
 (defonce root
-  (rdom/createRoot
+  (createRoot
    (js/document.getElementById "app")))
 
 (defn render []

--- a/src/main/component.cljs
+++ b/src/main/component.cljs
@@ -1,13 +1,14 @@
 (ns main.component
-  (:require ["@mantine/core" :as mc]
-            ["@mantine/hooks" :as mh]
+  (:require ["@mantine/core" :refer [AppShell Burger Button createTheme Group
+                                     Skeleton]]
+            ["@mantine/hooks" :refer [useDisclosure]]
             [helix.core :refer [$ <>]]
             [helix.dom :as d]
             [helix.hooks :as hooks]
             [main.lib :refer [defnc]]))
 
 (def theme
-  (mc/createTheme
+  (createTheme
    (clj->js
     {:colors {:deep-blue ["#eef3ff" "#dce4f5" "#b9c7e2" "#94a8d0" "#748dc1" "#5f7cb8" "#5474b4" "#44639f" "#39588f" "#2d4b81"]
               :yellow-king ["#fafae8" "#f0f1da" "#e0e1b9" "#cfd094" "#c0c274" "#b7b95f" "#b2b454" "#9c9e44" "#8a8c39" "#767a2b"]}
@@ -20,7 +21,7 @@
   (<> (if value "yes" "no")))
 
 (defnc button [{:keys [color on-click text]}]
-  ($ mc/Button {:color color :onClick on-click} text))
+  ($ Button {:color color :onClick on-click} text))
 
 (defnc counter []
   (let [[count set-count] (hooks/use-state 0)]
@@ -29,27 +30,27 @@
       ($ button {:color "blue" :on-click #(set-count inc) :text "Increase"}))))
 
 (defnc app-shell []
-  (let [[opened fns] (mh/useDisclosure)
+  (let [[opened fns] (useDisclosure)
         {:keys [toggle]} (js->clj fns :keywordize-keys true)]
-    ($ mc/AppShell {:padding "md"
-                    :header #js {:height 60}
-                    :navbar #js {:width 300
-                                 :breakpoint "md"
-                                 :collapsed #js {:mobile (not opened)}}}
+    ($ AppShell {:padding "md"
+                 :header #js {:height 60}
+                 :navbar #js {:width 300
+                              :breakpoint "md"
+                              :collapsed #js {:mobile (not opened)}}}
 
-       ($ mc/AppShell.Header
-          ($ mc/Group {:h "100%" :px "md"}
-             ($ mc/Burger {:opened opened
-                           :onClick toggle
-                           :hiddenFrom "sm"
-                           :size "sm"})
+       ($ (.-Header AppShell)
+          ($ Group {:h "100%" :px "md"}
+             ($ Burger {:opened opened
+                        :onClick toggle
+                        :hiddenFrom "sm"
+                        :size "sm"})
              (d/div "Helix + Mantine")))
 
-       ($ mc/AppShell.Navbar {:p "md"}
+       ($ (.-Navbar AppShell) {:p "md"}
           (for [index (range 10)]
-            ($ mc/Skeleton {:key index :h 28 :mt "sm" :animate false})))
+            ($ Skeleton {:key index :h 28 :mt "sm" :animate false})))
 
-       ($ mc/AppShell.Main
+       ($ (.-Main AppShell)
           (d/h1 "helix-jsdom-portfolio-mantine")
           ($ button {:text "My Button"
                      :on-click #(js/console.log "clicked!")


### PR DESCRIPTION
The `:refer` requires when used with the (.-Header AppShell) is safe.

More info in: https://clojurians.slack.com/archives/C6N245JGG/p1710356012813239?thread_ts=1709735502.619379&cid=C6N245JGG

It's due to how externs are generated, `AppSehll.Header` will be renamed as is not recognized as a valid extern.